### PR TITLE
[FEAT] Add exclusiveBetween

### DIFF
--- a/src/Validate.test.ts
+++ b/src/Validate.test.ts
@@ -1,6 +1,36 @@
 import { Validate } from './Validate';
 
 describe('Validate', () => {
+  describe('Validate.exclusiveBetween', () => {
+    it('does not throw if the value is within bounds', () => {
+      function shouldNotThrow(): void {
+        Validate.exclusiveBetween(0, 10, 5, 'test');
+      }
+      expect(shouldNotThrow).not.toThrowError();
+    });
+
+    it('throws with the provided message if the value is on the lower bound', () => {
+      function shouldThrow(): void {
+        Validate.exclusiveBetween(0, 10, 0, 'test');
+      }
+      expect(shouldThrow).toThrowError('test');
+    });
+
+    it('throws with the provided message if the value is on the upper bound', () => {
+      function shouldThrow(): void {
+        Validate.exclusiveBetween(0, 10, 10, 'test');
+      }
+      expect(shouldThrow).toThrowError('test');
+    });
+
+    it('throws with the provided message if the value is not within bounds', () => {
+      function shouldThrow(): void {
+        Validate.exclusiveBetween(0, 1, 2, 'test');
+      }
+      expect(shouldThrow).toThrowError('test');
+    });
+  });
+
   describe('Validate.inclusiveBetween', () => {
     it('does not throw if the value is within bounds', () => {
       function shouldNotThrow(): void {

--- a/src/Validate.ts
+++ b/src/Validate.ts
@@ -8,6 +8,22 @@ import { ValidateNegation } from './ValidateNegation';
  */
 export class Validate {
   /**
+   * Validates that the provided number is exclusively between the start and
+   * end; otherwise, throws a RangeError.
+   *
+   * @param start the exclusive start value
+   * @param end the exclusive end value
+   * @param value the number to validate
+   * @param message RangeError message if the value is outside the boundaries
+   * @throws RangeError if the value is outside the boundaries
+   */
+  public static exclusiveBetween(start: number, end: number, value: number, message: string): void {
+    if (value <= start || value >= end) {
+      throw new RangeError(message);
+    }
+  }
+
+  /**
    * Validates that the provided number is inclusively between the start and
    * end; otherwise, throws a RangeError.
    *

--- a/src/ValidateNegation.test.ts
+++ b/src/ValidateNegation.test.ts
@@ -1,6 +1,36 @@
 import { ValidateNegation } from './ValidateNegation';
 
 describe('ValidateNegation', () => {
+  describe('ValidateNegation.exclusiveBetween', () => {
+    it('does not throw if the value is out of bounds', () => {
+      function shouldNotThrow(): void {
+        ValidateNegation.exclusiveBetween(0, 1, 2, 'test');
+      }
+      expect(shouldNotThrow).not.toThrowError();
+    });
+
+    it('does not throw if the value is on the lower bound', () => {
+      function shouldNotThrow(): void {
+        ValidateNegation.exclusiveBetween(0, 1, 0, 'test');
+      }
+      expect(shouldNotThrow).not.toThrowError('test');
+    });
+
+    it('does not throw if the value is on the upper bound', () => {
+      function shouldNotThrow(): void {
+        ValidateNegation.exclusiveBetween(0, 10, 10, 'test');
+      }
+      expect(shouldNotThrow).not.toThrowError('test');
+    });
+
+    it('throws with the provided message if the value is within bounds', () => {
+      function shouldThrow(): void {
+        ValidateNegation.exclusiveBetween(0, 10, 5, 'test');
+      }
+      expect(shouldThrow).toThrowError('test');
+    });
+  });
+
   describe('ValidateNegation.inclusiveBetween', () => {
     it('does not throw if the value is out of bounds', () => {
       function shouldNotThrow(): void {
@@ -10,17 +40,17 @@ describe('ValidateNegation', () => {
     });
 
     it('throws with the provided message if the value is on the lower bound', () => {
-      function shouldNotThrow(): void {
+      function shouldThrow(): void {
         ValidateNegation.inclusiveBetween(0, 10, 0, 'test');
       }
-      expect(shouldNotThrow).toThrowError('test');
+      expect(shouldThrow).toThrowError('test');
     });
 
     it('throws with the provided message if the value is on the upper bound', () => {
-      function shouldNotThrow(): void {
+      function shouldThrow(): void {
         ValidateNegation.inclusiveBetween(0, 10, 10, 'test');
       }
-      expect(shouldNotThrow).toThrowError('test');
+      expect(shouldThrow).toThrowError('test');
     });
 
     it('throws with the provided message if the value is within bounds', () => {

--- a/src/ValidateNegation.ts
+++ b/src/ValidateNegation.ts
@@ -1,4 +1,10 @@
 export class ValidateNegation {
+  public static exclusiveBetween(start: number, end: number, value: number, message: string): void {
+    if (!(value <= start || value >= end)) {
+      throw new RangeError(message);
+    }
+  }
+
   public static inclusiveBetween(start: number, end: number, value: number, message: string): void {
     if (!(value < start || value > end)) {
       throw new RangeError(message);


### PR DESCRIPTION
# Summary

Adds `exclusiveBetween` that validates that a number is within (excluding boundaries) a range.

## Details

- add `Validate.exclusiveBetween`, `ValidateNegation.exclusiveBetween`
- Fix function names in test