### PR TITLE
Add Release Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "lint": "npm run lint:js && npm run lint:md",
     "lint:js": "eslint . --color --ext .ts src",
     "lint:md": "markdownlint --ignore \"**/node_modules/**\" .",
-    "release": "release-it",
-    "release:beta": "release-it --preRelease=beta",
+    "release": "cross-env ./scripts/release-it.sh",
+    "release:beta": "cross-env ./scripts/release-it.sh --beta",
     "test": "jest",
     "test:coverage": "npm run clean:jest && jest --colors --coverage",
     "test:watch": "jest --watch"

--- a/scripts/release-it.sh
+++ b/scripts/release-it.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+npm i
+npm run lint
+npm run test
+npm run build:clean
+
+if [ "$1" == "" ]; then
+  ./node_modules/.bin/release-it
+elif [ "$1" == "--beta" ]; then
+  ./node_modules/.bin/release-it --preRelease=beta
+else
+  echo "$1 is not recognized"
+  exit 1
+fi


### PR DESCRIPTION
# Summary

Adds a release script to easily manage `release-it`.

## Details

- 🔧 package.json `release` scripts now call `scripts/release-it.sh`
- this new script runs all tests/lint etc before releasing

## Notes

- `release-it` hooks was not working on windows (at least for me), so this is an interrim solution
