### PR TITLE
Add Coverage Workflow for PRs and master/release pushes

### DIFF
--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -34,5 +34,5 @@ jobs:
           type: lcov
           result_path: coverage/lcov.info
           min_coverage: 100
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{secrets.DEVMASX_COVERAGE_CHECK_ACTION_GH_TOKEN}}
 

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -1,0 +1,37 @@
+name: coverage-check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - 'releases/*'
+
+jobs:
+  run-test:
+    runs-on: ubuntu-latest
+    steps:
+      -
+         name: Checkout
+         uses: actions/checkout@v1
+      -
+         name: Run Tests
+         run: |
+           npm install
+           npm run test:coverage
+    
+  coverage-check:
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Checkout
+        uses: actions/checkout@v1
+      - 
+        name: Coverage check
+        uses: devmasx/coverage-check-action@v1.1.0
+        with:
+          type: lcov
+          result_path: coverage/lcov.info
+          min_coverage: 100
+          token: ${{secrets.GITHUB_TOKEN}}
+

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -8,7 +8,7 @@ on:
       - 'releases/*'
 
 jobs:
-  run-test:
+  coverage-check:
     runs-on: ubuntu-latest
     steps:
       -
@@ -19,15 +19,7 @@ jobs:
          run: |
            npm install
            npm run test:coverage
-    
-  coverage-check:
-    runs-on: ubuntu-latest
-    needs: [run-test]
-    steps:
-      - 
-        name: Checkout
-        uses: actions/checkout@v1
-      - 
+      -
         name: Coverage check
         uses: devmasx/coverage-check-action@v1.1.0
         with:

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -22,6 +22,7 @@ jobs:
     
   coverage-check:
     runs-on: ubuntu-latest
+    needs: [run-test]
     steps:
       - 
         name: Checkout


### PR DESCRIPTION
# Summary

Adds a GH Workflow for checking coverage to PRs and pushes.

## Details

- new workflow file
- uses devmasx/coverage-check-action@v1.1.0